### PR TITLE
Fetch image immediately before presenting/sending

### DIFF
--- a/herald/index.js
+++ b/herald/index.js
@@ -53,15 +53,15 @@ function killViewerProcess() {
   return viewerProcess.then(lose, lose);
 }
 
-function startViewerProcess(location, duration) {
+async function startViewerProcess(imageStream, duration) {
   // defer to the termination of any existing viewer process
   if (viewerProcess) {
-    return killViewerProcess().then(
-      startViewerProcess.bind(null, location, duration));
+    await killViewerProcess();
+    return startViewerProcess(imageStream, duration);
   }
 
   // set up a new viewer process
-  viewerProcess = asDesktopUser`feh -F ${location}`;
+  viewerProcess = asDesktopUser({input: imageStream})`feh -F -`;
 
   // log any errors, except the one we're expecting
   viewerProcess.catch(logNonSigTermErrors);
@@ -70,10 +70,13 @@ function startViewerProcess(location, duration) {
   if (duration) {
     viewerTimeout = setTimeout(killViewerProcess, duration);
   }
+}
 
-  // ensure that we're returning a resolved Promise context,
-  // whether this was called from killViewerProcess.then or not
-  return Promise.resolve();
+async function fetchAndDisplay(location, duration) {
+  const res = await fetch(location);
+  if (!res.ok) throw new Error(
+    `HTTP error fetching image: ${response.status} ${response.statusText}`);
+  return startViewerProcess(res.body, duration);
 }
 
 app.post('/present/still', (req, res, next) => {
@@ -81,9 +84,9 @@ app.post('/present/still', (req, res, next) => {
     // wake the display
     asDesktopUser`xset dpms force on`,
     // present the still
-    startViewerProcess(req.query.location, req.query.duration)
+    fetchAndDisplay(req.query.location, req.query.duration)
 
-    ].map(p=>p.catch(next))).then(()=>res.send());
+    ].map(p => p.catch(next))).then(() => res.send());
 });
 
 app.listen(80);

--- a/herald/index.js
+++ b/herald/index.js
@@ -2,6 +2,7 @@ import {Gpio} from 'onoff';
 import morgan from 'morgan';
 import {$} from 'execa';
 import express from 'express';
+import {Readable} from 'stream';
 
 // Relay for ringing the doorbell.
 const relay = new Gpio(4, 'high', {activeLow: true});
@@ -76,7 +77,7 @@ async function fetchAndDisplay(location, duration) {
   const res = await fetch(location);
   if (!res.ok) throw new Error(
     `HTTP error fetching image: ${response.status} ${response.statusText}`);
-  return startViewerProcess(res.body, duration);
+  return startViewerProcess(Readable.fromWeb(res.body), duration);
 }
 
 app.post('/present/still', (req, res, next) => {

--- a/sentinel/index.js
+++ b/sentinel/index.js
@@ -2,6 +2,7 @@ import {Gpio} from 'onoff';
 import debounce from 'debounce';
 import {v4 as uuid} from 'uuid';
 import nodemailer from 'nodemailer';
+import {Readable} from 'stream';
 
 const sensor = new Gpio(3, 'in', 'both');
 
@@ -75,7 +76,7 @@ async function sendEmailNotification() {
     html: `<img src="cid:${cid}">`,
     attachments: [{
       filename: EMAIL_ATTACHMENT_FILENAME,
-      content: res.body,
+      content: Readable.fromWeb(res.body),
       cid }]
   });
 }

--- a/sentinel/index.js
+++ b/sentinel/index.js
@@ -61,8 +61,11 @@ const mailer = EMAIL_RECIPIENT && nodemailer.createTransport({
   },
 });
 
-function sendEmailNotification() {
+async function sendEmailNotification() {
   const cid = uuid();
+  const res = await fetch(SNAP_URL);
+  if (!res.ok) throw new Error(
+    `HTTP error fetching image: ${response.status} ${response.statusText}`);
   return mailer.sendMail({
     from: {name: EMAIL_SENDER_NAME, address: EMAIL_SENDER_ADDRESS},
     to: EMAIL_RECIPIENT,
@@ -72,7 +75,7 @@ function sendEmailNotification() {
     html: `<img src="cid:${cid}">`,
     attachments: [{
       filename: EMAIL_ATTACHMENT_FILENAME,
-      path: SNAP_URL,
+      content: res.body,
       cid }]
   });
 }


### PR DESCRIPTION
Closes #1 with a slightly more modern approach that also prefetches the image before emailing it from the sentinel.

The only marginally-significant loss between that PR and this one is that I decided the `HTTPResponseError` class was overkill over just throwing a `new Error`. If I ever refactor this project to be more of a [Service-Weaver-esque](https://serviceweaver.dev/) monolith, I might reintroduce that as art of a lightweight internal module (ie. as the error thrown by a wrapper around `fetch` if the status is not 200).